### PR TITLE
1.4.1 Changes

### DIFF
--- a/files/js/editor_element.js
+++ b/files/js/editor_element.js
@@ -4,6 +4,9 @@
  */
 (function() {
     var SimpleTable = PlatformElement.extend({
+        // default/minimum column width, in a percentage-based format
+        minColumnWidth: 5,
+
         // a lot of setup is here; setting the sizes of the columns,
         // normalizing styles, and making the table resizable.
         initialize: function() {
@@ -33,7 +36,7 @@
         listenForPlaceholderReplacement: function() {
             var view = this;
             this.placeholderTimeout = setInterval(function() {
-                if (this.$('.platform-element-child-placeholder').length == 0) {
+                if (this.$('.platform-element-child-placeholder').length === 0) {
                     this.fixStyles();
                     this.setUpResizable();
                     clearInterval(this.placeholderTimeout);
@@ -45,15 +48,63 @@
         setSizes: function() {
             var sizes = this.settings.get('tableSizes');
             if (sizes && sizes != "default") {
-                // if the # of columns isn't the size of the array of lengths, ignore it.
-                if (this.settings.get('columns') == sizes.length) {
-                    var columns = this.$('tr:first-child td').map(function(index, value) {
-                        $(value).css('width', sizes[index] + '%');
+                if (this.settings.get('columns') > sizes.length) {
+                    // we need to make more columns.
+                    // to do this, we take each existing column and proportionally remove a bit of width to make room.
+                    // no columns will ever go under the minimum column size.
+                    // new columns will have the minimum column size.
+
+                    // get normalized total width
+                    // i.e., [45, 5, 50] => [40, 0, 45] => 95
+                    var normalizedTotalWidth = sizes.reduce(function(a, b) { return a + b; }, 0) - sizes.length * this.minColumnWidth;
+
+                    // the number of columns we have to add
+                    var diff = this.settings.get('columns') - sizes.length;
+
+                    // then subtract porportionally to make room for the new columns
+                    // i.e. [45, 5, 50] => [42.74, 5, 47.26]
+                    // (more was taken out of 50 than of 45, and the total sum is now 95 instead of 100)
+                    sizes.map(function(a) {
+                        return a - ((a - this.minColumnWidth) * ((diff * this.minColumnWidth) / normalizedTotalWidth));
+                    }.bind(this));
+
+                    // then add new columns.
+                    for (var i = 0; i < diff; i++) {
+                        sizes.push(this.minColumnWidth);
+                    }
+
+                    // save the new array of widths.
+                    this.settings.set('tableSizes', sizes);
+                    this.settings.save();
+                } else if (this.settings.get('columns') < sizes.length) {
+                    // we need to remove the extra columns.
+                    // proportionally redistribute the columns that will get deleted;
+                    // i.e., [40, 20, 20, 20] would become [50, 25, 25] if the last column got deleted
+
+                    // get total size of elements being removed
+                    var size = 0;
+                    while (this.settings.get('columns') != sizes.length) {
+                        size += sizes.pop();
+                    }
+
+                    // get total sizes of remaining widths
+                    var totalWidth = sizes.reduce(function(a, b) { return a + b; }, 0);
+
+                    // then redistribute sizes accordingly
+                    sizes.map(function(a) {
+                        a += size * (a / totalWidth);
                     });
-                } else {
-                    this.settings.unset('tableSizes');
+
+                    // save the new array of widths
+                    this.settings.set('tableSizes', sizes);
                     this.settings.save();
                 }
+
+                // now sizes is an array w/ the proper number of columns
+                // apply the sizes!
+                var columns = this.$('tr:first-child td').map(function(index, value) {
+                    $(value).css('width', sizes[index] + '%');
+                });
             }
         },
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "elements": [
     {
       "name": "Simple Table",
       "path": "files",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
Changes:

* Better support for keeping table widths when users add/remove columns. Previously, we would ignore and reset column widths if the number of columns in a table didn't match the array length of the stored sizes. Now, we do two things:
  * When a user adds an additional column, we make room for the column by proportionally resizing the other columns to make space. Example: Say we have four columns with percentage widths `[65, 25, 5, 5]`, and the minimum percentage width for any column is 5. When we go to add an additional column of width 5, the new column sizes will be `[61.25, 23.75, 5, 5, 5]`. This keeps the proportions of excess column width beyond the minimum the same.
  * When a user deletes a column, we proportionally distribute the width of the column(s) that were deleted. i.e., if a user has four columns with widths `[40, 20, 20, 20]`, deleting the last column will make the new widths `[50, 25, 25]`.

@M-Porter @jennieab 