### PR TITLE
Firefox mobile width fix

### DIFF
--- a/files/css/element.css
+++ b/files/css/element.css
@@ -9,6 +9,7 @@
     width: 100%;
     border: @border;
     border-spacing: 0;
+    table-layout: fixed;
 
     .cells();
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "elements": [
     {
       "name": "Simple Table",
       "path": "files",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
Fixes an issue on firefox mobile where the table would appear past the width of the screen.

@szainmehdi @rchen1992 @wormbytes 